### PR TITLE
fix: excess configuration items

### DIFF
--- a/docs/en/guide/deployment/k8s-only.mdx
+++ b/docs/en/guide/deployment/k8s-only.mdx
@@ -107,7 +107,6 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
        - ReadWriteOnce
      hostPath:
        path: /mnt/path/to/gzctf/db # local path
-   apiVersion: v1
    ---
    apiVersion: v1
    kind: PersistentVolumeClaim

--- a/docs/ja/guide/deployment/k8s-only.mdx
+++ b/docs/ja/guide/deployment/k8s-only.mdx
@@ -107,7 +107,6 @@
        - ReadWriteOnce
      hostPath:
        path: /mnt/path/to/gzctf/db # ローカルのパス
-   apiVersion: v1
    ---
    apiVersion: v1
    kind: PersistentVolumeClaim

--- a/docs/zh/guide/deployment/k8s-only.mdx
+++ b/docs/zh/guide/deployment/k8s-only.mdx
@@ -107,7 +107,6 @@
        - ReadWriteOnce
      hostPath:
        path: /mnt/path/to/gzctf/db # 本地路径
-   apiVersion: v1
    ---
    apiVersion: v1
    kind: PersistentVolumeClaim


### PR DESCRIPTION
in [*Use K8s Only*](https://gzctf.gzti.me/guide/deployment/k8s-only.html), Create local PV

before:

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: gzctf-db-pv
  namespace: gzctf-server
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteOnce
  hostPath:
    path: /mnt/path/to/gzctf/db # local path
apiVersion: v1
```

after:

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: gzctf-db-pv
  namespace: gzctf-server
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteOnce
  hostPath:
    path: /mnt/path/to/gzctf/db # local path
```