### PR TITLE
add: Notes about S3 storage support (en)

### DIFF
--- a/docs/en/guide/deployment/k8s-only.mdx
+++ b/docs/en/guide/deployment/k8s-only.mdx
@@ -32,7 +32,7 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
 
 ## Deploying GZCTF
 
-1. Create namespaces and configuration files
+1. Create namespaces and configuration files. See [appsettings](/config/config/appsettings)
 
    ```yaml
    apiVersion: v1

--- a/docs/en/guide/deployment/k8s-only.mdx
+++ b/docs/en/guide/deployment/k8s-only.mdx
@@ -11,7 +11,7 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
 ## Deployment Notes
 
 1. GZCTF supports multi-instance deployment, but based on testing, currently the most stable deployment method is a single-instance deployment with the database on the same node. Therefore, this article will focus on single-instance deployment as an example.
-2. For multi-instance deployment, all instances need to mount the shared storage as Persistent Volumes (PV) to ensure file consistency. Additionally, Redis needs to be deployed to ensure cache consistency among multiple instances.
+2. For multi-instance deployment, all instances need to use S3/Object Storage to ensure file consistency and write concurenncy (See [#365](https://github.com/GZTimeWalker/GZCTF/issues/365)). Additionally, Redis needs to be deployed to ensure cache consistency among multiple instances. Refer to [appsettings](/config/config/appsettings) documentation to configure both.
 3. For multi-instance deployment, the load balancer needs to be configured with sticky sessions to enable real-time data retrieval using websockets.
 4. **If you prefer a simpler deployment, go for a single-instance deployment!**
 5. Since you have chosen to deploy with Kubernetes, it implies that you need a larger number of Pods. Please pay attention to the following configuration:
@@ -89,9 +89,9 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
      namespace: gzctf-server
    spec:
      capacity:
-       storage: 2Gi
+       storage: 2Gi # If you configured S3 storage then this PV will be used for storing logs only  so 2Gi is too much
      accessModes:
-       - ReadWriteOnce # Please change to ReadWriteMany when deploying multiple instances
+       - ReadWriteOnce
      hostPath:
        path: /mnt/path/to/gzctf/files # local path
    ---
@@ -115,10 +115,10 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
      namespace: gzctf-server
    spec:
      accessModes:
-       - ReadWriteOnce # Please change to ReadWriteMany when deploying multiple instances
+       - ReadWriteOnce
      resources:
        requests:
-         storage: 2Gi
+         storage: 2Gi # If you configured S3 storage then this PV will be used for storing logs only so 2Gi is too much
      volumeName: gzctf-files-pv
    ---
    apiVersion: v1

--- a/docs/en/guide/deployment/k8s-only.mdx
+++ b/docs/en/guide/deployment/k8s-only.mdx
@@ -11,7 +11,7 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
 ## Deployment Notes
 
 1. GZCTF supports multi-instance deployment, but based on testing, currently the most stable deployment method is a single-instance deployment with the database on the same node. Therefore, this article will focus on single-instance deployment as an example.
-2. For multi-instance deployment, all instances need to use S3/Object Storage to ensure file consistency and write concurenncy (See [#365](https://github.com/GZTimeWalker/GZCTF/issues/365)). Additionally, Redis needs to be deployed to ensure cache consistency among multiple instances. Refer to [appsettings](/config/config/appsettings) documentation to configure both.
+2. For multi-instance deployment, all instances need to use S3/Object Storage to ensure file consistency and write concurenncy (See [#365](https://github.com/GZTimeWalker/GZCTF/issues/365)). Additionally, Redis needs to be deployed to ensure cache consistency among multiple instances. Refer to [appsettings](/config/config/appsettings) documentation to configure both. Multiple providers are supported such as Azure/AWS/Minio.
 3. For multi-instance deployment, the load balancer needs to be configured with sticky sessions to enable real-time data retrieval using websockets.
 4. **If you prefer a simpler deployment, go for a single-instance deployment!**
 5. Since you have chosen to deploy with Kubernetes, it implies that you need a larger number of Pods. Please pay attention to the following configuration:


### PR DESCRIPTION
- No need for ReadWriteMany because S3 is a preferred option in a multi-instance deployment
- Put links to appsettings.json docs
- Put a note that PersistentVolume size of 2Gi is too large since it would only be used for logs in the case of using S3

Support for S3 was added https://github.com/GZTimeWalker/GZCTF/issues/365