### PR TITLE
fix: wrong layout of LogoHeader

### DIFF
--- a/theme/components/LogoHeader.tsx
+++ b/theme/components/LogoHeader.tsx
@@ -13,7 +13,12 @@ export const LogoHeader: FC = () => {
     <div style={{ display: "flex", alignItems: "center", gap: "2px" }}>
       <Link
         href={lang === defaultLang ? "/" : lang}
-        className="flex items-center w-full h-full text-base font-semibold transition-opacity duration-300 hover:opacity-60"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          width: "100%",
+          height: "100%",
+        }}
       >
         <MainIcon width={40} height={40} />
         <span


### PR DESCRIPTION
Before|After
:-:|:-:
![before](https://github.com/user-attachments/assets/858106be-cd24-4c6c-9e10-d13d54a084eb)|![after](https://github.com/user-attachments/assets/4321f912-6a95-4fb5-b4e8-1c400579acd4)
